### PR TITLE
Query flags result in optional args

### DIFF
--- a/test/golden/expected/query_flag.rb
+++ b/test/golden/expected/query_flag.rb
@@ -16,12 +16,12 @@ module Generated
         @http.use_ssl = @origin.scheme == 'https'
       end
 
-      def get_uri(beetle)
+      def get_uri(beetle: false)
         URI("#{@origin}?#{beetle ? 'beetle' : ''}")
       end
 
-      def get(beetle)
-        req = Net::HTTP::Get.new(get_uri(beetle))
+      def get(beetle: false)
+        req = Net::HTTP::Get.new(get_uri(beetle: beetle))
 
         @http.request(req)
       end


### PR DESCRIPTION
Use case: we'd love to add a query flag to an existing endpoint in a backwards compatible manner. This makes it possible by using optional ruby args for query parameters.