### PR TITLE
Fix bug in query flag casing

### DIFF
--- a/src/Servant/Ruby.hs
+++ b/src/Servant/Ruby.hs
@@ -389,7 +389,7 @@ paramToStr :: QueryArg f -> Text
 paramToStr qarg =
   case qarg ^. queryArgType of
     Normal -> key <> "=#{" <> val <> "}"
-    Flag   -> "#{" <> key <> " ? '" <> key <> "' : ''}"
+    Flag   -> "#{" <> snake key <> " ? '" <> key <> "' : ''}"
     List   -> "#{ " <> val <> ".collect { |x| '" <> key <> "[]=' + x.to_s }.join('&') }"
   where
   key = qarg ^. queryArgName.argName._PathSegment

--- a/test/golden/Main.hs
+++ b/test/golden/Main.hs
@@ -39,7 +39,7 @@ type QueryParamApi = QueryParam "spider" () :> Get '[JSON] ()
 
 type QueryParamsApi = QueryParams "spiders" () :> Get '[JSON] ()
 
-type QueryFlagApi = QueryFlag "beetle" :> Get '[JSON] ()
+type QueryFlagApi = QueryFlag "vw-beetle" :> Get '[JSON] ()
 
 test
   :: (GenerateList NoContent (Foreign NoContent api), HasForeign NoTypes NoContent api)

--- a/test/golden/expected/query_flag.rb
+++ b/test/golden/expected/query_flag.rb
@@ -16,12 +16,12 @@ module Generated
         @http.use_ssl = @origin.scheme == 'https'
       end
 
-      def get_uri(beetle: false)
-        URI("#{@origin}?#{beetle ? 'beetle' : ''}")
+      def get_uri(vw_beetle: false)
+        URI("#{@origin}?#{vw_beetle ? 'vw-beetle' : ''}")
       end
 
-      def get(beetle: false)
-        req = Net::HTTP::Get.new(get_uri(beetle: beetle))
+      def get(vw_beetle: false)
+        req = Net::HTTP::Get.new(get_uri(vw_beetle: vw_beetle))
 
         @http.request(req)
       end


### PR DESCRIPTION
We weren't using the snake-cased variable name for a query flag in all
the places we were using the query flag.