### PR TITLE
Allow mutating requests before firing

### DIFF
--- a/test/golden/expected/body.rb
+++ b/test/golden/expected/body.rb
@@ -20,9 +20,11 @@ module Generated
         URI("#{@origin}")
       end
 
-      def post(body:)
+      def post(body:, &block)
         req = Net::HTTP::Post.new(post_uri())
         req["Content-Type"] = "application/json"
+
+        block.call(req) if block_given?
 
         @http.request(req, body)
       end

--- a/test/golden/expected/header.rb
+++ b/test/golden/expected/header.rb
@@ -20,9 +20,11 @@ module Generated
         URI("#{@origin}")
       end
 
-      def post(moth:)
+      def post(moth:, &block)
         req = Net::HTTP::Post.new(post_uri())
         req["moth"] = moth
+
+        block.call(req) if block_given?
 
         @http.request(req)
       end

--- a/test/golden/expected/parameters.rb
+++ b/test/golden/expected/parameters.rb
@@ -22,10 +22,12 @@ module Generated
         URI("#{@origin}/#{butterfly}")
       end
 
-      def get_by_butterfly(butterfly)
+      def get_by_butterfly(butterfly, &block)
         butterfly = if butterfly.kind_of?(Array) then butterfly.join(',') else butterfly end
 
         req = Net::HTTP::Get.new(get_by_butterfly_uri(butterfly))
+
+        block.call(req) if block_given?
 
         @http.request(req)
       end

--- a/test/golden/expected/query_flag.rb
+++ b/test/golden/expected/query_flag.rb
@@ -20,8 +20,10 @@ module Generated
         URI("#{@origin}?#{vw_beetle ? 'vw-beetle' : ''}")
       end
 
-      def get(vw_beetle: false)
+      def get(vw_beetle: false, &block)
         req = Net::HTTP::Get.new(get_uri(vw_beetle: vw_beetle))
+
+        block.call(req) if block_given?
 
         @http.request(req)
       end

--- a/test/golden/expected/query_param.rb
+++ b/test/golden/expected/query_param.rb
@@ -20,8 +20,10 @@ module Generated
         URI("#{@origin}?spider=#{spider}")
       end
 
-      def get(spider)
+      def get(spider, &block)
         req = Net::HTTP::Get.new(get_uri(spider))
+
+        block.call(req) if block_given?
 
         @http.request(req)
       end

--- a/test/golden/expected/query_params.rb
+++ b/test/golden/expected/query_params.rb
@@ -20,8 +20,10 @@ module Generated
         URI("#{@origin}?#{ spiders.collect { |x| 'spiders[]=' + x.to_s }.join('&') }")
       end
 
-      def get(spiders)
+      def get(spiders, &block)
         req = Net::HTTP::Get.new(get_uri(spiders))
+
+        block.call(req) if block_given?
 
         @http.request(req)
       end

--- a/test/golden/expected/static.rb
+++ b/test/golden/expected/static.rb
@@ -20,8 +20,10 @@ module Generated
         URI("#{@origin}/hello/world")
       end
 
-      def get_hello_world()
+      def get_hello_world(&block)
         req = Net::HTTP::Get.new(get_hello_world_uri())
+
+        block.call(req) if block_given?
 
         @http.request(req)
       end


### PR DESCRIPTION
# Merge after https://github.com/NoRedInk/servant-ruby/pull/6

I want to add headers to requests before firing them and I think this might be an OK way to do it.

I could monkey-patch http to add my headers, but I've seen some issues saying aws-sdk was already monkey-patching it and wrecking havoc everywhere bc of it.